### PR TITLE
CI: restore the CI_DESIRED_RUNTIME check

### DIFF
--- a/hack/ci/ci.sh
+++ b/hack/ci/ci.sh
@@ -28,7 +28,12 @@ limactl copy "$REPO_DIR" $LIMA_VM_NAME:/var/tmp/podman
 
 set +e
 
-limactl shell --workdir /var/tmp/podman $LIMA_VM_NAME ./hack/ci/runner.sh "${@}"
+# limactl shell does not forward the host environment, so pass GITHUB_ACTIONS
+# in explicitly. The tests use it to tell "running in CI" from "running on a
+# dev laptop", and must fail rather than skip when a CI_DESIRED_* variable is
+# missing in CI. See #14912.
+limactl shell --workdir /var/tmp/podman $LIMA_VM_NAME \
+    env GITHUB_ACTIONS="$GITHUB_ACTIONS" ./hack/ci/runner.sh "${@}"
 rc=$?
 
 limactl shell --workdir /var/tmp/podman $LIMA_VM_NAME sudo ./hack/ci/logcollector.sh journal &> "$SCRIPT_DIR/journal.log"

--- a/hack/ci/runner.sh
+++ b/hack/ci/runner.sh
@@ -11,7 +11,7 @@ source "$SCRIPT_DIR/lib.sh"
 
 parse_args "$@"
 
-PRESERVE_ENVS="CI_USE_REGISTRY_CACHE,CI_DESIRED_COMPOSEFS,OCI_RUNTIME,CGROUP_MANAGER,STORAGE_FS,STORAGE_OPTIONS_OVERLAY,STORAGE_OPTIONS_VFS,PODMAN_UPGRADE_FROM"
+PRESERVE_ENVS="CI_USE_REGISTRY_CACHE,CI_DESIRED_COMPOSEFS,CI_DESIRED_RUNTIME,GITHUB_ACTIONS,OCI_RUNTIME,CGROUP_MANAGER,STORAGE_FS,STORAGE_OPTIONS_OVERLAY,STORAGE_OPTIONS_VFS,PODMAN_UPGRADE_FROM"
 # run as root or or not
 SUDO=""
 if [[ "$PRIV" == "root" ]]; then
@@ -19,6 +19,12 @@ if [[ "$PRIV" == "root" ]]; then
 fi
 
 STORAGE_FS=overlay
+
+# The tests assert the runtime podman actually reports is the one CI intends,
+# see #14912. As of 2024-05-28 there are no other supported runtimes.
+# Deliberately a literal: OCI_RUNTIME is the input that selects the runtime, so
+# deriving this from it would compare the value against itself and never fail.
+CI_DESIRED_RUNTIME=crun
 
 case "$DISTRO_NAME" in
 fedora-current)
@@ -58,6 +64,7 @@ fi
 ## Used in tests so we need to export them
 export STORAGE_FS
 export CI_DESIRED_COMPOSEFS
+export CI_DESIRED_RUNTIME
 
 ### SETUP HERE
 

--- a/test/e2e/info_test.go
+++ b/test/e2e/info_test.go
@@ -124,13 +124,13 @@ var _ = Describe("Podman Info", func() {
 	})
 
 	It("Podman info: check desired runtime", func() {
-		// defined in .cirrus.yml
+		// defined in hack/ci/runner.sh
 		want := os.Getenv("CI_DESIRED_RUNTIME")
 		if want == "" {
-			if os.Getenv("CIRRUS_CI") == "" {
-				Skip("CI_DESIRED_RUNTIME is not set--this is OK because we're not running under Cirrus")
+			if os.Getenv("GITHUB_ACTIONS") == "" {
+				Skip("CI_DESIRED_RUNTIME is not set--this is OK because we're not running in GitHub Actions")
 			}
-			Fail("CIRRUS_CI is set, but CI_DESIRED_RUNTIME is not! See #14912")
+			Fail("GITHUB_ACTIONS is set, but CI_DESIRED_RUNTIME is not! See #14912")
 		}
 		session := podmanTest.PodmanExitCleanly("info", "--format", "{{.Host.OCIRuntime.Name}}")
 		Expect(session.OutputToString()).To(Equal(want))

--- a/test/system/005-info.bats
+++ b/test/system/005-info.bats
@@ -67,20 +67,20 @@ store.imageStore.number   | 1
 
 @test "podman info - confirm desired runtime" {
     if [[ -z "$CI_DESIRED_RUNTIME" ]]; then
-        # When running in Cirrus, CI_DESIRED_RUNTIME *must* be defined
-        # in .cirrus.yml so we can double-check that all CI VMs are
+        # When running in GitHub Actions, CI_DESIRED_RUNTIME *must* be defined
+        # in hack/ci/runner.sh so we can double-check that all CI VMs are
         # using crun/runc as desired.
-        if [[ -n "$CIRRUS_CI" ]]; then
-            die "CIRRUS_CI is set, but CI_DESIRED_RUNTIME is not! See #14912"
+        if [[ -n "$GITHUB_ACTIONS" ]]; then
+            die "GITHUB_ACTIONS is set, but CI_DESIRED_RUNTIME is not! See #14912"
         fi
 
-        # Not running under Cirrus (e.g., gating tests, or dev laptop).
+        # Not running in GitHub Actions (e.g., gating tests, or dev laptop).
         # Totally OK to skip this test.
-        skip "CI_DESIRED_RUNTIME is unset--OK, because we're not in Cirrus"
+        skip "CI_DESIRED_RUNTIME is unset--OK, because we're not in GitHub Actions"
     fi
 
     run_podman info --format '{{.Host.OCIRuntime.Name}}'
-    is "$output" "$CI_DESIRED_RUNTIME" "CI_DESIRED_RUNTIME (from .cirrus.yml)"
+    is "$output" "$CI_DESIRED_RUNTIME" "CI_DESIRED_RUNTIME (from hack/ci/runner.sh)"
 }
 
 @test "podman info - confirm desired network backend" {


### PR DESCRIPTION
CI_DESIRED_RUNTIME was only set in .cirrus.yml, and that file went away with
3743b9f806 ("Goodbye Cirrus"). The tests that read it are still there though,
so right now both of these just skip on every run:

- test/e2e/info_test.go, "Podman info: check desired runtime"
- test/system/005-info.bats, "podman info - confirm desired runtime"

When the var is empty they check CIRRUS_CI as a fallback, and that's obviously
never set under GHA, so they always hit the skip and the die()/Fail() under it
is unreachable. So the check from #14912 hasn't actually run since we moved off
Cirrus.

You can see it with:

    git show 3743b9f806^:.cirrus.yml | grep CI_DESIRED
    grep -rn CI_DESIRED_RUNTIME --include=*.yml .

So I set the variable in runner.sh and switched both tests to check
GITHUB_ACTIONS instead.

Couple of things I'm not sure about:

I ended up touching ci.sh too. limactl shell doesn't pass the host env into the
VM, so GITHUB_ACTIONS never reaches the tests and they'd have kept skipping
anyway. Passing it in explicitly was the simplest thing I could come up with,
happy to change it if you'd do it some other way. Both vars are in
PRESERVE_ENVS for the same reason, otherwise sudo drops them in the rootful
jobs.

I also hardcoded crun instead of deriving it from OCI_RUNTIME. I did derive it
at first, then realised OCI_RUNTIME is what picks the runtime in the first
place, so the test would just be comparing the value against itself and could
never fail. .cirrus.yml hardcoded it too so I'm guessing that was the point.

Left CI_DESIRED_STORAGE alone even though it's broken the same way. .cirrus.yml
set it to composefs on rawhide but STORAGE_FS there is overlay, and I couldn't
work out which one .Store.GraphDriverName is supposed to match. Can do it as a
follow up, or in here if you tell me which is right.

make validatepr passes. The real test is CI though, the desired runtime tests
should actually run now instead of skipping.