### PR TITLE
test/system: increase _check_health timeout to fix CI flake

### DIFF
--- a/test/system/220-healthcheck.bats
+++ b/test/system/220-healthcheck.bats
@@ -18,10 +18,10 @@ function _check_health {
     local hc_status="$5"
 
     # Loop-wait (up to a few seconds) for healthcheck event (#20342)
-    # Allow a margin when running parallel, because of system load
-    local timeout=5
-    if [[ -n "$PARALLEL_JOBSLOT" ]]; then
-        timeout=$((timeout + 3))
+    # Allow a generous margin when running parallel or in CI, because of system load
+    local timeout=15
+    if [[ -n "$PARALLEL_JOBSLOT" || -n "$CI" ]]; then
+        timeout=$((timeout + 10))
     fi
 
     while :; do


### PR DESCRIPTION
Ref #29353

### Summary
The `_check_health` test helper in `test/system/220-healthcheck.bats` previously used a 5-second timeout (8 seconds when running parallel). Under heavy parallel load on GitHub Actions CI runners, systemd timers for container healthchecks take longer to execute 3 retries, causing false-positive test timeouts while `FailingStreak` is at 2.

### Changes
- Increased base timeout in `_check_health` to 15s (25s when running in `$CI` or parallel `$PARALLEL_JOBSLOT` jobs).
- Ensures `podman events` polling loop allows sufficient margin for systemd timer execution under CI load without flaking.

### Checklist
- [x] Code is signed off (`git commit -s`)
- [x] Tests pass / modified test updated
