### PR TITLE
test/e2e/healthcheck: skip ignore-result test on non-amd64

### DIFF
--- a/test/e2e/healthcheck_run_test.go
+++ b/test/e2e/healthcheck_run_test.go
@@ -169,6 +169,7 @@ var _ = Describe("Podman healthcheck run", func() {
 	})
 
 	It("podman healthcheck --ignore-result exits 0 on failing healthcheck", func() {
+		SkipIfNotAMD64() // https://github.com/containers/podman/issues/28269
 		session := podmanTest.Podman([]string{"run", "-q", "-dt", "--name", "hc", "quay.io/libpod/badhealthcheck:latest"})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())


### PR DESCRIPTION
The badhealthcheck image is available only on amd64.

Skip the test on non-amd64 hosts.

Otherwise tests fails with:

```
# Test messages # [It] Podman healthcheck run podman healthcheck --ignore-result exits 0 on failing healthcheck
# failure: 

Unexpected warnings seen on stderr: "time=\"2026-08-03T05:47:41-04:00\" level=warning msg=\"image platform (linux/amd64) does not match the expected platform (linux/arm64)\""
[FAILED] Unexpected warnings seen on stderr: "time=\"2026-08-03T05:47:41-04:00\" level=warning msg=\"image platform (linux/amd64) does not match the expected platform (linux/arm64)\""
In [It] at: /var/tmp/podman/test/e2e/healthcheck_run_test.go:174 @ 08/03/26 05:47:41.413
```

https://openqa.opensuse.org/tests/6141919#external

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
