### PR TITLE
Packit/TF config update and skip jobs on unavailable composes

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -166,6 +166,7 @@ jobs:
     packages: [podman-fedora]
     dist_git_branches: &fedora_targets
       - fedora-rawhide
+      - fedora-45
 
   - job: koji_build
     trigger: commit

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -103,6 +103,7 @@ jobs:
   - job: tests
     trigger: pull_request
     packages: [podman-fedora]
+    skip_missing_branched_composes: true
     notifications: *packit_generic_failure_notification
     targets:
       - fedora-all
@@ -117,6 +118,7 @@ jobs:
     identifier: cockpit-revdeps
     trigger: pull_request
     packages: [podman-fedora]
+    skip_missing_branched_composes: true
     notifications:
       failure_comment:
         message: "Cockpit tests failed for commit {commit_sha}. @jelly, @mvollmer please check."


### PR DESCRIPTION
Packit has a new flag to disable testing-farm jobs when a compose is not available.
Ref: https://github.com/packit/packit-service/issues/2992

Also, enabled fedora-45 downstream update job as it'll be branching from rawhide soon.

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note
None
```
