### PR TITLE
machine/wsl: detect native systemd as running

### DIFF
--- a/pkg/machine/wsl/declares.go
+++ b/pkg/machine/wsl/declares.go
@@ -49,6 +49,15 @@ or type exit. This also means to log out you need to exit twice.
 
 const sysdpid = "SYSDPID=`ps -eo cmd,pid | grep -m 1 ^/lib/systemd/systemd | awk '{print $2}'`"
 
+const systemdRunning = `
+if [ "$(basename "$(readlink -f /proc/1/exe 2>/dev/null)")" = "systemd" ]; then
+    echo 1
+else
+    ` + sysdpid + `
+    echo $SYSDPID
+fi
+`
+
 const profile = sysdpid + `
 if [ ! -z "$SYSDPID" ] && [ "$SYSDPID" != "1" ]; then
     cat /etc/wslmotd

--- a/pkg/machine/wsl/machine.go
+++ b/pkg/machine/wsl/machine.go
@@ -520,7 +520,7 @@ func getAllWSLDistros(running bool) (map[string]struct{}, error) {
 
 func isSystemdRunning(dist string) (bool, error) {
 	cmd := wutil.NewWSLCommand("-u", "root", "-d", dist, "sh")
-	cmd.Stdin = strings.NewReader(sysdpid + "\necho $SYSDPID\n")
+	cmd.Stdin = strings.NewReader(systemdRunning)
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
- **docs: fix --image-volume default and accepted values**
- **podman: warn on deprecated --image-volume=bind**
- **rootless: fix heap-buffer-overflow in preexec hooks**
- **Update module google.golang.org/grpc to v1.83.0**
- **Bump main to v6.2.0-dev**
- **Update zizmorcore/zizmor-action action to v0.6.2**
- **test/e2e/healthcheck: skip ignore-result test on non-amd64**
- **packit: Skip tests when branched composes are unavailable**
- **packit: Add fedora-45 to downstream targets**
- **link org wide LLM_POLICY**
- **Add dnsnames field & fix alias field**
- **fix: update packit failure-notification team to new org**
- **machine/wsl: detect native systemd as running**

<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [ ] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [ ] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [ ] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [ ] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [ ] All commits pass `make validatepr` (format/lint checks)
- [ ] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

<!--
Write `None` if there are no user-facing changes, otherwise enter your release note below.
Include "action required" if users need to take action when upgrading.
-->

```release-note

```
