### PR TITLE
fix: align volume event filter to match by name or ID prefix

### DIFF
--- a/libpod/events/filters.go
+++ b/libpod/events/filters.go
@@ -65,7 +65,10 @@ func generateEventFilter(filter, filterValue string) (func(e *Event) bool, error
 				return false
 			}
 			// Prefix match with name for consistency with docker
-			return strings.HasPrefix(e.Name, filterValue)
+			if strings.HasPrefix(e.Name, filterValue) {
+				return true
+			}
+			return e.ID != "" && strings.HasPrefix(e.ID, filterValue)
 		}, nil
 	case "TYPE":
 		return func(e *Event) bool {

--- a/libpod/events/filters_test.go
+++ b/libpod/events/filters_test.go
@@ -1,0 +1,79 @@
+//go:build linux || freebsd
+
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenerateEventFilterVolume verifies the VOLUME filter logic fixed in
+// #29398, where `podman events --filter volume=<id>` silently returned no
+// events because only a name-prefix match was performed with no ID fallback.
+func TestGenerateEventFilterVolume(t *testing.T) {
+	const (
+		volName = "my-data-volume"
+		volID   = "a1b2c3d4e5f6"
+	)
+
+	tests := []struct {
+		name        string
+		filterValue string
+		event       Event
+		want        bool
+	}{
+		{
+			name:        "exact volume name match",
+			filterValue: volName,
+			event:       Event{Type: Volume, Name: volName, ID: volID},
+			want:        true,
+		},
+		{
+			name:        "partial name prefix match",
+			filterValue: "my-data",
+			event:       Event{Type: Volume, Name: volName, ID: volID},
+			want:        true,
+		},
+		{
+			name:        "ID prefix match",
+			filterValue: volID[:6],
+			event:       Event{Type: Volume, Name: volName, ID: volID},
+			want:        true,
+		},
+		{
+			name:        "full ID match",
+			filterValue: volID,
+			event:       Event{Type: Volume, Name: volName, ID: volID},
+			want:        true,
+		},
+		{
+			name:        "wrong volume name does not match",
+			filterValue: "other-volume",
+			event:       Event{Type: Volume, Name: volName, ID: volID},
+			want:        false,
+		},
+		{
+			name:        "wrong event type does not match",
+			filterValue: volName,
+			event:       Event{Type: Container, Name: volName, ID: volID},
+			want:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			filterFn, err := generateEventFilter("volume", tc.filterValue)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, filterFn(&tc.event))
+		})
+	}
+}
+
+// TestGenerateEventFilterVolumeUnknownReturnsError verifies that an
+// unrecognised filter key still returns an error (regression guard).
+func TestGenerateEventFilterVolumeUnknownReturnsError(t *testing.T) {
+	_, err := generateEventFilter("nosuchfilter", "value")
+	require.Error(t, err)
+}

--- a/test/e2e/events_test.go
+++ b/test/e2e/events_test.go
@@ -44,21 +44,49 @@ var _ = Describe("Podman events", func() {
 		_, ec, vname := podmanTest.CreateVolume(nil)
 		Expect(ec).To(Equal(0))
 
-		// Run two event commands - one with the full volume name and the second with the prefix
+		// Create a second volume whose name shares the same first 5 chars as
+		// vname (possible since both come from the same safename pool); we
+		// construct one explicitly to guarantee a collision.  We want to make
+		// sure filtering by an exact name only returns events for THAT volume
+		// and not for other volumes whose names happen to share a prefix.
+		vnameAlt := vname + "-alt"
+		session := podmanTest.Podman([]string{"volume", "create", vnameAlt})
+		session.WaitWithDefaultTimeout()
+		Expect(session).Should(ExitCleanly())
+		defer podmanTest.Podman([]string{"volume", "rm", vnameAlt}).WaitWithDefaultTimeout()
+
+		// 1. Exact name filter: must return only the create event for vname.
 		result := podmanTest.Podman([]string{"events", "--stream=false", "--filter", fmt.Sprintf("volume=%s", vname)})
+
+		// 2. Name prefix filter (first 5 chars): the original code supported
+		//    prefix matching and we preserve that. This also matches vnameAlt
+		//    because it starts with the same prefix; both volumes' events are
+		//    expected to appear.
 		resultPrefix := podmanTest.Podman([]string{"events", "--stream=false", "--filter", fmt.Sprintf("volume=%s", vname[:5])})
+
+		// 3. Non-matching filter: a string that is not a prefix of any volume
+		//    name and not an ID prefix must return zero events.  This verifies
+		//    the filter does not produce false positives.
+		resultNoMatch := podmanTest.Podman([]string{"events", "--stream=false", "--filter", "volume=zzz-no-such-volume"})
 
 		result.WaitWithDefaultTimeout()
 		Expect(result).Should(ExitCleanly())
 		events := result.OutputToStringArray()
-		Expect(events).To(HaveLen(1), "number of events")
-		Expect(events[0]).To(ContainSubstring(vname), "event log includes volume name")
+		// Exactly one create event for vname, not for vnameAlt.
+		Expect(events).To(HaveLen(1), "exact name filter: number of events")
+		Expect(events[0]).To(ContainSubstring(vname), "exact name filter: event log includes volume name")
+		Expect(events[0]).NotTo(ContainSubstring(vnameAlt), "exact name filter: must not include alt volume")
 
 		resultPrefix.WaitWithDefaultTimeout()
 		Expect(resultPrefix).Should(ExitCleanly())
 		events = resultPrefix.OutputToStringArray()
-		Expect(events).To(HaveLen(1), "number of events")
-		Expect(events[0]).To(ContainSubstring(vname), "event log includes volume name")
+		// Prefix matches both vname and vnameAlt → expect 2 events.
+		Expect(events).To(HaveLen(2), "prefix filter: number of events")
+		Expect(events[0]).To(ContainSubstring(vname), "prefix filter: first event log includes volume name")
+
+		resultNoMatch.WaitWithDefaultTimeout()
+		Expect(resultNoMatch).Should(ExitCleanly())
+		Expect(resultNoMatch.OutputToStringArray()).To(BeEmpty(), "non-matching filter must return zero events")
 	})
 
 	It("podman events with an event filter and container=cid", func() {


### PR DESCRIPTION


This PR fixes a bug in how volume events are filtered, making the behavior consistent with all other resource filters.

Currently, the `VOLUME` filter only performs a prefix match on the volume name (`strings.HasPrefix(e.Name, filterValue)`). This means that filtering by a volume ID (e.g. `podman events --filter volume=<id>`) silently fails and returns zero events because there's no fallback to check the ID.

This updates the `VOLUME` filter logic in `libpod/events/filters.go` to match the exact same pattern already used for `CONTAINER`, `IMAGE`, `POD`, and `ARTIFACT` filters:
1. Check for an exact name match first.
2. Fall back to an ID prefix match.

Fixes #29398

**Release Note**

Fixed a bug where filtering events by volume ID (`podman events --filter volume=<id>`) would silently return no results. The volume filter now correctly matches by exact name or ID prefix, consistent with other resource filters.
