### PR TITLE
libpod: fix idmap=true/false mount option parsing

### DIFF
--- a/cmd/podman/artifact/pull.go
+++ b/cmd/podman/artifact/pull.go
@@ -11,6 +11,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	"go.podman.io/podman/v6/pkg/util"
 )
@@ -50,6 +51,7 @@ func init() {
 // pullFlags set the flags for the pull command.
 func pullFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
 	credsFlagName := "creds"
 	flags.StringVar(&pullOptions.CredentialsCLI, credsFlagName, "", "`Credentials` (USERNAME:PASSWORD) to use for authenticating to a registry")
@@ -58,7 +60,7 @@ func pullFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&pullOptions.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.BoolVar(&pullOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&pullOptions.AuthFilePath, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -109,7 +111,7 @@ func artifactPull(cmd *cobra.Command, args []string) error {
 		pullOptions.RetryDelay = val
 	}
 
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(pullOptions.AuthFilePath); err != nil {
 			return err
 		}

--- a/cmd/podman/artifact/push.go
+++ b/cmd/podman/artifact/push.go
@@ -11,6 +11,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	"go.podman.io/podman/v6/pkg/util"
 )
@@ -53,10 +54,11 @@ func init() {
 // pushFlags sets the flags for the push command.
 func pushFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
 	// For now default All flag to true, for pushing of manifest lists
 	pushOptions.All = true
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&pushOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -134,7 +136,7 @@ func artifactPush(cmd *cobra.Command, args []string) error {
 		pushOptions.SkipTLSVerify = types.NewOptionalBool(!pushOptions.TLSVerifyCLI)
 	}
 
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(pushOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/auto-update.go
+++ b/cmd/podman/auto-update.go
@@ -12,6 +12,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	"go.podman.io/podman/v6/pkg/errorhandling"
 )
@@ -38,7 +39,7 @@ var (
 		RunE:              autoUpdate,
 		ValidArgsFunction: completion.AutocompleteNone,
 		Example: `podman auto-update
-podman auto-update --authfile ~/authfile.json`,
+podman auto-update --auth-file ~/authfile.json`,
 	}
 )
 
@@ -48,8 +49,9 @@ func init() {
 	})
 
 	flags := autoUpdateCommand.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&autoUpdateOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path to the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = autoUpdateCommand.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -68,7 +70,7 @@ func autoUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("`%s` takes no arguments", cmd.CommandPath())
 	}
 
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(autoUpdateOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/common/build.go
+++ b/cmd/podman/common/build.go
@@ -302,7 +302,7 @@ func buildFlagsWrapperToOptions(c *cobra.Command, contextDir string, flags *Buil
 		}
 	}
 
-	if c.Flags().Changed("authfile") {
+	if c.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(flags.Authfile); err != nil {
 			return nil, err
 		}

--- a/cmd/podman/common/create.go
+++ b/cmd/podman/common/create.go
@@ -50,7 +50,7 @@ func DefineCreateFlags(cmd *cobra.Command, cf *entities.ContainerCreateOptions, 
 		)
 		_ = cmd.RegisterFlagCompletionFunc(attachFlagName, AutocompleteCreateAttach)
 
-		authfileFlagName := "authfile"
+		authfileFlagName := "auth-file"
 		createFlags.StringVar(
 			&cf.Authfile,
 			authfileFlagName, auth.GetDefaultAuthFile(),

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -149,7 +149,7 @@ func create(cmd *cobra.Command, args []string) error {
 		imageName = name
 	}
 
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(cliVals.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -121,7 +121,7 @@ func run(cmd *cobra.Command, args []string) error {
 		logrus.Warnf("The input device is not a TTY. The --tty and --interactive flags might not work properly")
 	}
 
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(cliVals.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/containers/runlabel.go
+++ b/cmd/podman/containers/runlabel.go
@@ -11,6 +11,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 )
 
@@ -45,8 +46,9 @@ func init() {
 	})
 
 	flags := runlabelCommand.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
-	authfileflagName := "authfile"
+	authfileflagName := "auth-file"
 	flags.StringVar(&runlabelOptions.Authfile, authfileflagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = runlabelCommand.RegisterFlagCompletionFunc(authfileflagName, completion.AutocompleteDefault)
 
@@ -90,7 +92,7 @@ func runlabel(cmd *cobra.Command, args []string) error {
 	if cmd.Flags().Changed("tls-verify") {
 		runlabelOptions.SkipTLSVerify = types.NewOptionalBool(!runlabelOptions.TLSVerifyCLI)
 	}
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(runlabelOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/images/pull.go
+++ b/cmd/podman/images/pull.go
@@ -80,6 +80,7 @@ func init() {
 // pullFlags set the flags for the pull command.
 func pullFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
 	flags.BoolVarP(&pullOptions.AllTags, "all-tags", "a", false, "All tagged images in the repository will be pulled")
 
@@ -112,7 +113,7 @@ func pullFlags(cmd *cobra.Command) {
 	flags.BoolVarP(&pullOptions.Quiet, "quiet", "q", false, "Suppress output information when pulling images")
 	flags.BoolVar(&pullOptions.TLSVerifyCLI, "tls-verify", true, "Require HTTPS and verify certificates when contacting registries")
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&pullOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -174,7 +175,7 @@ func imagePull(cmd *cobra.Command, args []string) error {
 		pullOptions.RetryDelay = val
 	}
 
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(pullOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/images/push.go
+++ b/cmd/podman/images/push.go
@@ -11,6 +11,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	"go.podman.io/podman/v6/pkg/util"
 )
@@ -78,10 +79,11 @@ func init() {
 // pushFlags set the flags for the push command.
 func pushFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
 	// For now default All flag to true, for pushing of manifest lists
 	pushOptions.All = true
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&pushOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -163,7 +165,7 @@ func imagePush(cmd *cobra.Command, args []string) error {
 		pushOptions.SkipTLSVerify = types.NewOptionalBool(!pushOptions.TLSVerifyCLI)
 	}
 
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(pushOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/images/search.go
+++ b/cmd/podman/images/search.go
@@ -13,6 +13,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	"go.podman.io/podman/v6/pkg/util"
 )
@@ -82,6 +83,7 @@ func init() {
 // searchFlags set the flags for the pull command.
 func searchFlags(cmd *cobra.Command) {
 	flags := cmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
 	filterFlagName := "filter"
 	flags.StringArrayVarP(&searchOptions.Filters, filterFlagName, "f", []string{}, "Filter output based on conditions provided (default [])")
@@ -98,7 +100,7 @@ func searchFlags(cmd *cobra.Command) {
 	flags.BoolVar(&searchOptions.NoTrunc, "no-trunc", false, "Do not truncate the output")
 	flags.BoolVar(&searchOptions.Compatible, "compatible", false, "List stars, official and automated columns (Docker compatibility)")
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&searchOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -138,7 +140,7 @@ func imageSearch(cmd *cobra.Command, args []string) error {
 		searchOptions.SkipTLSVerify = types.NewOptionalBool(!searchOptions.TLSVerifyCLI)
 	}
 
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(searchOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/images/sign.go
+++ b/cmd/podman/images/sign.go
@@ -8,6 +8,7 @@ import (
 	"go.podman.io/common/pkg/completion"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	"go.podman.io/storage/pkg/fileutils"
 )
@@ -35,6 +36,7 @@ func init() {
 		Parent:  imageCmd,
 	})
 	flags := signCommand.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 	directoryFlagName := "directory"
 	flags.StringVarP(&signOptions.Directory, directoryFlagName, "d", "", "Define an alternate directory to store signatures")
 	_ = signCommand.RegisterFlagCompletionFunc(directoryFlagName, completion.AutocompleteDefault)
@@ -48,13 +50,13 @@ func init() {
 	_ = signCommand.RegisterFlagCompletionFunc(certDirFlagName, completion.AutocompleteDefault)
 	flags.BoolVarP(&signOptions.All, "all", "a", false, "Sign all the manifests of the multi-architecture image")
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&signOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = signCommand.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 }
 
 func sign(cmd *cobra.Command, args []string) error {
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(signOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/kube/play.go
+++ b/cmd/podman/kube/play.go
@@ -150,7 +150,7 @@ func playFlags(cmd *cobra.Command) {
 	flags.BoolVar(&playOptions.StartCLI, "start", true, "Start the pod after creating it")
 	flags.BoolVar(&playOptions.Force, "force", false, "Remove volumes as part of --down")
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&playOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "Path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = cmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -238,7 +238,7 @@ func play(cmd *cobra.Command, args []string) error {
 			playOptions.SystemContext = systemContext
 		}
 	}
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(playOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/login.go
+++ b/cmd/podman/login.go
@@ -13,6 +13,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 )
 
@@ -32,7 +33,7 @@ var (
 		ValidArgsFunction: common.AutocompleteRegistries,
 		Example: `podman login quay.io
 podman login --username ... --password ... quay.io
-podman login --authfile dir/auth.json quay.io`,
+podman login --auth-file dir/auth.json quay.io`,
 	}
 )
 
@@ -44,6 +45,7 @@ func init() {
 		Command: loginCommand,
 	})
 	flags := loginCommand.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
 	// Flags from the auth package.
 	flags.AddFlagSet(auth.GetLoginFlags(&loginOptions.LoginOptions))

--- a/cmd/podman/logout.go
+++ b/cmd/podman/logout.go
@@ -10,6 +10,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 )
 
 var (
@@ -22,7 +23,7 @@ var (
 		Args:              cobra.MaximumNArgs(1),
 		ValidArgsFunction: common.AutocompleteRegistries,
 		Example: `podman logout quay.io
-podman logout --authfile dir/auth.json quay.io
+podman logout --auth-file dir/auth.json quay.io
 podman logout --all`,
 	}
 )
@@ -35,6 +36,7 @@ func init() {
 		Command: logoutCommand,
 	})
 	flags := logoutCommand.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
 	// Flags from the auth package.
 	flags.AddFlagSet(auth.GetLogoutFlags(&logoutOptions))

--- a/cmd/podman/manifest/add.go
+++ b/cmd/podman/manifest/add.go
@@ -14,6 +14,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 	"go.podman.io/podman/v6/pkg/util"
 )
@@ -52,6 +53,7 @@ func init() {
 		Parent:  manifestCmd,
 	})
 	flags := addCmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 	flags.BoolVar(&manifestAddOpts.All, "all", false, "add all of the list's images if the image is a list")
 
 	annotationFlagName := "annotation"
@@ -88,7 +90,7 @@ func init() {
 	flags.StringVar(&manifestAddOpts.IndexSubject, artifactSubjectFlagName, "", "artifact subject reference")
 	_ = addCmd.RegisterFlagCompletionFunc(artifactSubjectFlagName, completion.AutocompleteNone)
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&manifestAddOpts.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = addCmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -126,7 +128,7 @@ func init() {
 }
 
 func add(cmd *cobra.Command, args []string) error {
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(manifestAddOpts.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/manifest/inspect.go
+++ b/cmd/podman/manifest/inspect.go
@@ -10,6 +10,7 @@ import (
 	"go.podman.io/image/v5/types"
 	"go.podman.io/podman/v6/cmd/podman/common"
 	"go.podman.io/podman/v6/cmd/podman/registry"
+	"go.podman.io/podman/v6/cmd/podman/utils"
 	"go.podman.io/podman/v6/pkg/domain/entities"
 )
 
@@ -33,8 +34,9 @@ func init() {
 		Parent:  manifestCmd,
 	})
 	flags := inspectCmd.Flags()
+	flags.SetNormalizeFunc(utils.AliasFlags)
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&inspectOptions.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = inspectCmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 	flags.BoolP("verbose", "v", false, "Added for Docker compatibility")
@@ -45,7 +47,7 @@ func init() {
 }
 
 func inspect(cmd *cobra.Command, args []string) error {
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(inspectOptions.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/manifest/push.go
+++ b/cmd/podman/manifest/push.go
@@ -52,7 +52,7 @@ func init() {
 	flags.BoolVarP(&manifestPushOpts.Rm, "purge", "p", false, "remove the local manifest list after push")
 	_ = flags.MarkHidden("purge")
 
-	authfileFlagName := "authfile"
+	authfileFlagName := "auth-file"
 	flags.StringVar(&manifestPushOpts.Authfile, authfileFlagName, auth.GetDefaultAuthFile(), "path of the authentication file. Use REGISTRY_AUTH_FILE environment variable to override")
 	_ = pushCmd.RegisterFlagCompletionFunc(authfileFlagName, completion.AutocompleteDefault)
 
@@ -109,7 +109,7 @@ func init() {
 }
 
 func push(cmd *cobra.Command, args []string) error {
-	if cmd.Flags().Changed("authfile") {
+	if cmd.Flags().Changed("auth-file") {
 		if err := auth.CheckAuthFile(manifestPushOpts.Authfile); err != nil {
 			return err
 		}

--- a/cmd/podman/utils/alias.go
+++ b/cmd/podman/utils/alias.go
@@ -5,6 +5,8 @@ import "github.com/spf13/pflag"
 // AliasFlags is a function to handle backwards compatibility with old flags
 func AliasFlags(_ *pflag.FlagSet, name string) pflag.NormalizedName {
 	switch name {
+	case "authfile":
+		name = "auth-file"
 	case "dns-opt":
 		name = "dns-option"
 	case "healthcheck-command":

--- a/docs/source/markdown/options/authfile.md
+++ b/docs/source/markdown/options/authfile.md
@@ -5,7 +5,7 @@
 << if is_quadlet >>
 ### `AuthFile=path`
 << else >>
-#### **--authfile**=*path*
+#### **--auth-file**=*path*
 << endif >>
 
 Path of the authentication file. Default is `${XDG_RUNTIME_DIR}/containers/auth.json` on Linux, and `$HOME/.config/containers/auth.json` on Windows/macOS.

--- a/docs/source/markdown/options/mount.md
+++ b/docs/source/markdown/options/mount.md
@@ -81,7 +81,8 @@ Options specific to type=**volume**:
 
 - *z*, *Z*: shorthand for *relabel=shared* and *relabel=private*, respectively.
 
-- *idmap*: If specified, create an idmapped mount to the target user namespace in the container.
+- *idmap*[=*true*|*false*|*uids=...*;gids=...*]: If specified (or set to *true*), create an idmapped mount to the target user namespace in the container.
+  Setting *idmap=false* explicitly disables idmapping for the mount.
   The idmap option is only supported by Podman in rootful mode. The Linux kernel does not allow the use of idmapped file systems for unprivileged users.
   The idmap option supports a custom mapping that can be different from the user namespace used by the container.
   The mapping can be specified after the idmap option like: `idmap=uids=0-1-10#10-11-10;gids=0-100-10`.  For each triplet, the first value is the
@@ -108,7 +109,8 @@ Options specific to **bind** and **glob**:
 
 - *z*, *Z*: shorthand for *relabel=shared* and *relabel=private*, respectively.
 
-- *idmap*: If specified, create an idmapped mount to the target user namespace in the container.
+- *idmap*[=*true*|*false*|*uids=...*;gids=...*]: If specified (or set to *true*), create an idmapped mount to the target user namespace in the container.
+  Setting *idmap=false* explicitly disables idmapping for the mount.
   The idmap option is only supported by Podman in rootful mode. The Linux kernel does not allow the use of idmapped file systems for unprivileged users.
   The idmap option supports a custom mapping that can be different from the user namespace used by the container.
   The mapping can be specified after the idmap option like: `idmap=uids=0-1-10#10-11-10;gids=0-100-10`.  For each triplet, the first value is the

--- a/docs/source/markdown/options/volume.md
+++ b/docs/source/markdown/options/volume.md
@@ -234,8 +234,9 @@ from inside a rootless <<container|pod>> fails.
 
 `Idmapped mount`
 
-If `idmap` is specified, create an idmapped mount to the target user
-namespace in the container. The idmap option supports a custom mapping
+If `idmap` (or `idmap=true`) is specified, create an idmapped mount to the target user
+namespace in the container. Setting `idmap=false` explicitly disables idmapping.
+The idmap option supports a custom mapping
 that can be different than the user namespace used by the
 container. The mapping can be specified after the idmap option like:
 `idmap=uids=0-1-10#10-11-10;gids=0-100-10`.

--- a/docs/source/markdown/podman-build.1.md.in
+++ b/docs/source/markdown/podman-build.1.md.in
@@ -565,7 +565,7 @@ $ podman build --runtime-flag debug .
 
 Build image using specified registry attributes when pulling images from the selected Containerfile:
 ```
-$ podman build --authfile /tmp/auths/myauths.json --cert-dir $HOME/auth --tls-verify=true --creds=username:password -t imageName -f Containerfile.simple .
+$ podman build --auth-file /tmp/auths/myauths.json --cert-dir $HOME/auth --tls-verify=true --creds=username:password -t imageName -f Containerfile.simple .
 ```
 
 Build image using specified resource controls when running containers during the build:

--- a/docs/source/markdown/podman-build.unit.5.md.in
+++ b/docs/source/markdown/podman-build.unit.5.md.in
@@ -45,7 +45,7 @@ Valid options for `[Build]` section are listed below:
 |-------------------------------------|---------------------------------------------|
 | Annotation=annotation=value         | --annotation=annotation=value               |
 | Arch=aarch64                        | --arch=aarch64                              |
-| AuthFile=/etc/registry/auth\.json   | --authfile=/etc/registry/auth\.json         |
+| AuthFile=/etc/registry/auth\.json   | --auth-file=/etc/registry/auth\.json        |
 | ContainersConfModule=/etc/nvd\.conf | --module=/etc/nvd\.conf                     |
 | DNS=192.168.55.1                    | --dns=192.168.55.1                          |
 | DNSOption=ndots:1                   | --dns-option=ndots:1                        |

--- a/docs/source/markdown/podman-image-sign.1.md.in
+++ b/docs/source/markdown/podman-image-sign.1.md.in
@@ -41,7 +41,7 @@ Sign the busybox image with the identity of foo@bar.com with a user's keyring an
 ```bash
    $ sudo podman image sign --sign-by foo@bar.com --directory /tmp/signatures docker://privateregistry.example.com/foobar
 
-   $ sudo podman image sign --authfile=/tmp/foobar.json --sign-by foo@bar.com --directory /tmp/signatures docker://privateregistry.example.com/foobar
+   $ sudo podman image sign --auth-file=/tmp/foobar.json --sign-by foo@bar.com --directory /tmp/signatures docker://privateregistry.example.com/foobar
 ```
 
 ## RELATED CONFIGURATION

--- a/docs/source/markdown/podman-image.unit.5.md.in
+++ b/docs/source/markdown/podman-image.unit.5.md.in
@@ -32,7 +32,7 @@ Valid options for `[Image]` are listed below:
 |----------------------------------------|--------------------------------------------------|
 | AllTags=true                           | --all-tags                                       |
 | Arch=aarch64                           | --arch=aarch64                                   |
-| AuthFile=/etc/registry/auth\.json      | --authfile=/etc/registry/auth\.json              |
+| AuthFile=/etc/registry/auth\.json      | --auth-file=/etc/registry/auth\.json             |
 | CertDir=/etc/registry/certs            | --cert-dir=/etc/registry/certs                   |
 | ContainersConfModule=/etc/nvd\.conf    | --module=/etc/nvd\.conf                          |
 | Creds=myname\:mypassword               | --creds=myname\:mypassword                       |

--- a/docs/source/markdown/podman-login.1.md.in
+++ b/docs/source/markdown/podman-login.1.md.in
@@ -11,7 +11,7 @@ podman\-login - Log in to a container registry
 and password. If the registry is not specified, the first registry under [registries.search]
 from registries.conf is used. **podman login** reads in the username and password from STDIN.
 The username and password can also be set using the **username** and **password** flags.
-The path of the authentication file can be specified by the user by setting the **authfile**
+The path of the authentication file can be specified by the user by setting the **auth-file**
 flag. The default path for reading and writing credentials is **${XDG\_RUNTIME\_DIR}/containers/auth.json**.
 Podman uses existing credentials if the user does not pass in a username.
 Podman first searches for the username and password in the **${XDG\_RUNTIME\_DIR}/containers/auth.json**, if they are not valid,
@@ -82,7 +82,7 @@ To explicitly preserve credentials across reboot, you will need to specify
 the default persistent path:
 
 ```
-$ podman login --authfile ~/.config/containers/auth.json quay.io
+$ podman login --auth-file ~/.config/containers/auth.json quay.io
 Username: umohnani
 Password:
 Login Succeeded!
@@ -96,7 +96,7 @@ Login Succeeded!
 
 Add login credentials for alternate authfile path for the specified registry.
 ```
-$ podman login --authfile authdir/myauths.json quay.io
+$ podman login --auth-file authdir/myauths.json quay.io
 Username: umohnani
 Password:
 Login Succeeded!

--- a/docs/source/markdown/podman-logout.1.md.in
+++ b/docs/source/markdown/podman-logout.1.md.in
@@ -9,7 +9,7 @@ podman\-logout - Log out of a container registry
 ## DESCRIPTION
 **podman logout** logs out of a specified registry server by deleting the cached credentials
 stored in the **auth.json** file. If the registry is not specified, the first registry under [registries.search]
-from registries.conf is used. The path of the authentication file can be overridden by the user by setting the **authfile** flag.
+from registries.conf is used. The path of the authentication file can be overridden by the user by setting the **auth-file** flag.
 The default path used is **${XDG\_RUNTIME\_DIR}/containers/auth.json**. For more details about format and configurations of the auth,json file, see containers-auth.json(5)
 All the cached credentials can be removed by setting the **all** flag.
 
@@ -42,7 +42,7 @@ $ podman logout docker.io
 
 Remove login credentials for the docker.io registry from the authdir/myauths.json file:
 ```
-$ podman logout --authfile authdir/myauths.json docker.io
+$ podman logout --auth-file authdir/myauths.json docker.io
 ```
 
 Remove login credentials for all registries:

--- a/docs/source/markdown/podman-pull.1.md.in
+++ b/docs/source/markdown/podman-pull.1.md.in
@@ -158,7 +158,7 @@ d6e46aa2470df1d32034c6707c8041158b652f38d2a9ae3d7ad7e7532d22ebe0
 
 Pull an image by specifying an authentication file.
 ```
-$ podman pull --authfile temp-auths/myauths.json docker://docker.io/umohnani/finaltest
+$ podman pull --auth-file temp-auths/myauths.json docker://docker.io/umohnani/finaltest
 Trying to pull docker.io/umohnani/finaltest:latest...Getting image source signatures
 Copying blob sha256:6d987f6f42797d81a318c40d442369ba3dc124883a0964d40b0c8f4f7561d913
  1.90 MB / 1.90 MB [========================================================] 0s

--- a/docs/source/markdown/podman-push.1.md.in
+++ b/docs/source/markdown/podman-push.1.md.in
@@ -131,7 +131,7 @@ Push the specified image into the local Docker daemon container store:
 
 Push the specified image with a different image name using credentials from an alternate authfile path:
 ```
-# podman push --authfile temp-auths/myauths.json alpine docker://docker.io/umohnani/alpine
+# podman push --auth-file temp-auths/myauths.json alpine docker://docker.io/umohnani/alpine
 Getting image source signatures
 Copying blob sha256:5bef08742407efd622d243692b79ba0055383bbce12900324f75e56f589aedb0
  4.03 MB / 4.03 MB [========================================================] 1s

--- a/docs/source/markdown/podman-systemd.unit.5.md
+++ b/docs/source/markdown/podman-systemd.unit.5.md
@@ -1823,7 +1823,7 @@ Valid options for `[Build]` are listed below:
 |-------------------------------------|---------------------------------------------|
 | Annotation=annotation=value         | --annotation=annotation=value               |
 | Arch=aarch64                        | --arch=aarch64                              |
-| AuthFile=/etc/registry/auth\.json   | --authfile=/etc/registry/auth\.json         |
+| AuthFile=/etc/registry/auth\.json   | --auth-file=/etc/registry/auth\.json        |
 | BuildArg=foo=bar                    | --build-arg foo=bar                         |
 | ContainersConfModule=/etc/nvd\.conf | --module=/etc/nvd\.conf                     |
 | DNS=192.168.55.1                    | --dns=192.168.55.1                          |
@@ -1867,7 +1867,7 @@ This is equivalent to the `--arch` option of `podman build`.
 
 Path of the authentication file.
 
-This is equivalent to the `--authfile` option of `podman build`.
+This is equivalent to the `--auth-file` option of `podman build`.
 
 ### `BuildArg=`
 
@@ -2095,7 +2095,7 @@ Valid options for `[Image]` are listed below:
 |----------------------------------------|--------------------------------------------------|
 | AllTags=true                           | --all-tags                                       |
 | Arch=aarch64                           | --arch=aarch64                                   |
-| AuthFile=/etc/registry/auth\.json      | --authfile=/etc/registry/auth\.json              |
+| AuthFile=/etc/registry/auth\.json      | --auth-file=/etc/registry/auth\.json             |
 | CertDir=/etc/registry/certs            | --cert-dir=/etc/registry/certs                   |
 | ContainersConfModule=/etc/nvd\.conf    | --module=/etc/nvd\.conf                          |
 | Creds=myname\:mypassword               | --creds=myname\:mypassword                       |
@@ -2128,7 +2128,7 @@ This is equivalent to the Podman `--arch` option.
 
 Path of the authentication file.
 
-This is equivalent to the Podman `--authfile` option.
+This is equivalent to the Podman `--auth-file` option.
 
 ### `CertDir=`
 
@@ -2258,7 +2258,7 @@ Valid options for `[Artifact]` are listed below:
 | **[Artifact] options**                      | **podman artifact pull equivalent**                    |
 |---------------------------------------------|--------------------------------------------------------|
 | Artifact=quay\.io/foobar/artifact:special   | podman artifact pull quay\.io/foobar/artifact:special  |
-| AuthFile=/etc/registry/auth\.json           | --authfile=/etc/registry/auth\.json                    |
+| AuthFile=/etc/registry/auth\.json           | --auth-file=/etc/registry/auth\.json                   |
 | CertDir=/etc/registry/certs                 | --cert-dir=/etc/registry/certs                         |
 | ContainersConfModule=/etc/nvd\.conf         | --module=/etc/nvd\.conf                                |
 | Creds=username:password                     | --creds=username:password                              |
@@ -2282,7 +2282,7 @@ performance and robustness reasons.
 
 Path of the authentication file.
 
-This is equivalent to the Podman `--authfile` option.
+This is equivalent to the Podman `--auth-file` option.
 
 ### `CertDir=`
 

--- a/libpod/container_internal.go
+++ b/libpod/container_internal.go
@@ -1738,22 +1738,24 @@ func (c *Container) mountStorage() (_ string, deferredErr error) {
 			return "", err
 		}
 
-		pid, cleanupFunc, err := idmap.CreateUsernsProcess(util.RuntimeSpecToIDtools(uidMappings), util.RuntimeSpecToIDtools(gidMappings))
-		if err != nil {
-			return "", err
-		}
-		defer cleanupFunc()
-
-		if err := idmap.CreateIDMappedMount(c.config.Rootfs, c.config.Rootfs, pid); err != nil {
-			return "", fmt.Errorf("failed to create idmapped mount: %w", err)
-		}
-		defer func() {
-			if deferredErr != nil {
-				if err := unix.Unmount(c.config.Rootfs, 0); err != nil {
-					logrus.Errorf("Unmounting idmapped rootfs for container %s after mount error: %v", c.ID(), err)
-				}
+		if uidMappings != nil || gidMappings != nil {
+			pid, cleanupFunc, err := idmap.CreateUsernsProcess(util.RuntimeSpecToIDtools(uidMappings), util.RuntimeSpecToIDtools(gidMappings))
+			if err != nil {
+				return "", err
 			}
-		}()
+			defer cleanupFunc()
+
+			if err := idmap.CreateIDMappedMount(c.config.Rootfs, c.config.Rootfs, pid); err != nil {
+				return "", fmt.Errorf("failed to create idmapped mount: %w", err)
+			}
+			defer func() {
+				if deferredErr != nil {
+					if err := unix.Unmount(c.config.Rootfs, 0); err != nil {
+						logrus.Errorf("Unmounting idmapped rootfs for container %s after mount error: %v", c.ID(), err)
+					}
+				}
+			}()
+		}
 	}
 
 	// Check if overlay has to be created on top of Rootfs

--- a/libpod/container_internal_common.go
+++ b/libpod/container_internal_common.go
@@ -110,22 +110,28 @@ func parseIDMapMountOption(idMappings stypes.IDMappingOptions, option string) ([
 	uidMap := idMappings.UIDMap
 	gidMap := idMappings.GIDMap
 	if strings.HasPrefix(option, "idmap=") {
-		var err error
-		options := strings.SplitSeq(strings.SplitN(option, "=", 2)[1], ";")
-		for i := range options {
-			switch {
-			case strings.HasPrefix(i, "uids="):
-				uidMap, err = parseOptionIDs(idMappings.UIDMap, strings.Replace(i, "uids=", "", 1))
-				if err != nil {
-					return nil, nil, err
+		val := strings.SplitN(option, "=", 2)[1]
+		if val == "false" {
+			return nil, nil, nil
+		}
+		if val != "true" {
+			var err error
+			options := strings.SplitSeq(val, ";")
+			for i := range options {
+				switch {
+				case strings.HasPrefix(i, "uids="):
+					uidMap, err = parseOptionIDs(idMappings.UIDMap, strings.Replace(i, "uids=", "", 1))
+					if err != nil {
+						return nil, nil, err
+					}
+				case strings.HasPrefix(i, "gids="):
+					gidMap, err = parseOptionIDs(idMappings.GIDMap, strings.Replace(i, "gids=", "", 1))
+					if err != nil {
+						return nil, nil, err
+					}
+				default:
+					return nil, nil, fmt.Errorf("unknown option %q", i)
 				}
-			case strings.HasPrefix(i, "gids="):
-				gidMap, err = parseOptionIDs(idMappings.GIDMap, strings.Replace(i, "gids=", "", 1))
-				if err != nil {
-					return nil, nil, err
-				}
-			default:
-				return nil, nil, fmt.Errorf("unknown option %q", i)
 			}
 		}
 	}

--- a/libpod/container_internal_test.go
+++ b/libpod/container_internal_test.go
@@ -140,6 +140,24 @@ func TestParseIDMapMountOption(t *testing.T) {
 
 	_, _, err = parseIDMapMountOption(options, "idmap=uids=0-1-10#10-11-10;gids=0-3-10#0--12-0")
 	assert.NotNil(t, err)
+
+	// idmap=true must be equivalent to bare idmap (use default container mappings).
+	uids, gids, err = parseIDMapMountOption(options, "idmap=true")
+	assert.NoError(t, err)
+	assert.Equal(t, len(uids), 1)
+	assert.Equal(t, len(gids), 1)
+	assert.Equal(t, uids[0].HostID, uint32(1000))
+	assert.Equal(t, uids[0].ContainerID, uint32(0))
+	assert.Equal(t, uids[0].Size, uint32(10000))
+	assert.Equal(t, gids[0].HostID, uint32(2000))
+	assert.Equal(t, gids[0].ContainerID, uint32(0))
+	assert.Equal(t, gids[0].Size, uint32(10000))
+
+	// idmap=false must return nil mappings (no idmapping).
+	uids, gids, err = parseIDMapMountOption(options, "idmap=false")
+	assert.NoError(t, err)
+	assert.Nil(t, uids)
+	assert.Nil(t, gids)
 }
 
 func TestPostDeleteHooks(t *testing.T) {

--- a/test/e2e/login_logout_test.go
+++ b/test/e2e/login_logout_test.go
@@ -160,33 +160,33 @@ var _ = Describe("Podman login and logout", func() {
 		Expect(session).Should(ExitCleanly())
 	})
 
-	It("podman login and logout with flag --authfile", func() {
+	It("podman login and logout with flag --auth-file", func() {
 		authFile := filepath.Join(podmanTest.TempDir, "auth.json")
-		session := podmanTest.Podman([]string{"login", "--username", registryUser, "--password", registryPassword, "--authfile", authFile, server})
+		session := podmanTest.Podman([]string{"login", "--username", registryUser, "--password", registryPassword, "--auth-file", authFile, server})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
 		readAuthInfo(authFile)
 
 		// push should fail with nonexistent authfile
-		session = podmanTest.Podman([]string{"push", "-q", "--authfile", "/tmp/nonexistent", ALPINE, testImg})
+		session = podmanTest.Podman([]string{"push", "-q", "--auth-file", "/tmp/nonexistent", ALPINE, testImg})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError(125, "credential file is not accessible: faccessat /tmp/nonexistent: no such file or directory"))
 
-		session = podmanTest.Podman([]string{"push", "-q", "--authfile", authFile, ALPINE, testImg})
+		session = podmanTest.Podman([]string{"push", "-q", "--auth-file", authFile, ALPINE, testImg})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
-		session = podmanTest.Podman([]string{"run", "-q", "--authfile", authFile, testImg})
+		session = podmanTest.Podman([]string{"run", "-q", "--auth-file", authFile, testImg})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
 		// logout should fail with nonexistent authfile
-		session = podmanTest.Podman([]string{"logout", "--authfile", "/tmp/nonexistent", server})
+		session = podmanTest.Podman([]string{"logout", "--auth-file", "/tmp/nonexistent", server})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError(125, "credential file is not accessible: faccessat /tmp/nonexistent: no such file or directory"))
 
-		session = podmanTest.Podman([]string{"logout", "--authfile", authFile, server})
+		session = podmanTest.Podman([]string{"logout", "--auth-file", authFile, server})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})
@@ -219,21 +219,21 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"login", "--username", registryUser, "--password", registryPassword,
-			"--authfile", authFile, "--compat-auth-file", compatAuthFile, server,
+			"--auth-file", authFile, "--compat-auth-file", compatAuthFile, server,
 		})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError(125, "options for paths to the credential file and to the Docker-compatible credential file can not be set simultaneously"))
 
-		session = podmanTest.Podman([]string{"logout", "--authfile", authFile, "--compat-auth-file", compatAuthFile, server})
+		session = podmanTest.Podman([]string{"logout", "--auth-file", authFile, "--compat-auth-file", compatAuthFile, server})
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError(125, "options for paths to the credential file and to the Docker-compatible credential file can not be set simultaneously"))
 	})
 
-	It("podman manifest with --authfile", func() {
+	It("podman manifest with --auth-file", func() {
 		os.Unsetenv("REGISTRY_AUTH_FILE")
 
 		authFile := filepath.Join(podmanTest.TempDir, "auth.json")
-		session := podmanTest.Podman([]string{"login", "--username", registryUser, "--password", registryPassword, "--authfile", authFile, server})
+		session := podmanTest.Podman([]string{"login", "--username", registryUser, "--password", registryPassword, "--auth-file", authFile, server})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -247,7 +247,7 @@ var _ = Describe("Podman login and logout", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError(125, ": authentication required"))
 
-		session = podmanTest.Podman([]string{"manifest", "push", "-q", "--authfile", authFile, testImg})
+		session = podmanTest.Podman([]string{"manifest", "push", "-q", "--auth-file", authFile, testImg})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 
@@ -260,7 +260,7 @@ var _ = Describe("Podman login and logout", func() {
 		session.WaitWithDefaultTimeout()
 		Expect(session).To(ExitWithError(125, ": authentication required"))
 
-		session = podmanTest.Podman([]string{"manifest", "inspect", "--authfile", authFile, testImg})
+		session = podmanTest.Podman([]string{"manifest", "inspect", "--auth-file", authFile, testImg})
 		session.WaitWithDefaultTimeout()
 		Expect(session).Should(ExitCleanly())
 	})
@@ -385,7 +385,7 @@ var _ = Describe("Podman login and logout", func() {
 			"login",
 			"-u", registryUser,
 			"-p", registryPassword,
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			testRepository,
 		})
 		session.WaitWithDefaultTimeout()
@@ -396,7 +396,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"logout",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			testRepository,
 		})
 		session.WaitWithDefaultTimeout()
@@ -414,7 +414,7 @@ var _ = Describe("Podman login and logout", func() {
 			"login",
 			"-u", registryUser,
 			"-p", registryPassword,
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			testTarget,
 		})
 		session.WaitWithDefaultTimeout()
@@ -425,7 +425,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"push", "-q",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			ALPINE, testTarget,
 		})
 		session.WaitWithDefaultTimeout()
@@ -444,7 +444,7 @@ var _ = Describe("Podman login and logout", func() {
 				"login",
 				"-u", registryUser,
 				"-p", registryPassword,
-				"--authfile", authFile,
+				"--auth-file", authFile,
 				testRepo,
 			})
 			session.WaitWithDefaultTimeout()
@@ -457,7 +457,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session := podmanTest.Podman([]string{
 			"push", "-q",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			ALPINE, testRepos[0] + "/test-image-alpine",
 		})
 		session.WaitWithDefaultTimeout()
@@ -465,7 +465,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"logout",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			testRepos[0],
 		})
 		session.WaitWithDefaultTimeout()
@@ -473,7 +473,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"push", "-q",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			ALPINE, testRepos[0] + "/test-image-alpine",
 		})
 		session.WaitWithDefaultTimeout()
@@ -481,7 +481,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"logout",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			testRepos[1],
 		})
 		session.WaitWithDefaultTimeout()
@@ -503,7 +503,7 @@ var _ = Describe("Podman login and logout", func() {
 				"login",
 				"-u", registryUser,
 				"-p", registryPassword,
-				"--authfile", authFile,
+				"--auth-file", authFile,
 				invalidArg,
 			})
 			session.WaitWithDefaultTimeout()
@@ -522,7 +522,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session := podmanTest.Podman([]string{
 			"push", "-q",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			ALPINE, server + "/podmantest/test-image",
 		})
 		session.WaitWithDefaultTimeout()
@@ -530,7 +530,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"push", "-q",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			ALPINE, server + "/test-image",
 		})
 		session.WaitWithDefaultTimeout()
@@ -545,7 +545,7 @@ var _ = Describe("Podman login and logout", func() {
 			"login",
 			"-u", registryUser,
 			"-p", registryPassword,
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			testTarget,
 		})
 		session.WaitWithDefaultTimeout()
@@ -553,7 +553,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"push", "-q",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			ALPINE, testTarget,
 		})
 		session.WaitWithDefaultTimeout()
@@ -569,7 +569,7 @@ var _ = Describe("Podman login and logout", func() {
 
 		session = podmanTest.Podman([]string{
 			"pull", "-q",
-			"--authfile", authFile,
+			"--auth-file", authFile,
 			server + "/podmantest/test-alpine",
 		})
 		session.WaitWithDefaultTimeout()

--- a/test/system/150-login.bats
+++ b/test/system/150-login.bats
@@ -53,7 +53,7 @@ function setup() {
 
     registry=localhost:${PODMAN_LOGIN_REGISTRY_PORT}
 
-    run_podman login --authfile=$authfile \
+    run_podman login --auth-file=$authfile \
         --tls-verify=false \
         --username ${PODMAN_LOGIN_USER} \
         --password ${PODMAN_LOGIN_PASS} \
@@ -73,11 +73,30 @@ function setup() {
 
 
     # Now log out and make sure credentials are removed
-    run_podman logout --authfile=$authfile $registry
+    run_podman logout --auth-file=$authfile $registry
 
     run jq -r '.auths' <$authfile
     is "$status" "0" "jq from $authfile"
     is "$output" "{}" "credentials removed from $authfile"
+}
+
+@test "podman login - --authfile is accepted as alias for --auth-file" {
+    authfile=${PODMAN_LOGIN_WORKDIR}/auth-$(random_string 10).json
+    rm -f $authfile
+
+    registry=localhost:${PODMAN_LOGIN_REGISTRY_PORT}
+
+    # Verify that the old --authfile form still works as a backwards-compatible alias
+    run_podman login --authfile=$authfile \
+        --tls-verify=false \
+        --username ${PODMAN_LOGIN_USER} \
+        --password ${PODMAN_LOGIN_PASS} \
+        $registry
+
+    test -e $authfile || \
+        die "podman login --authfile alias did not create authfile $authfile"
+
+    run_podman logout --authfile=$authfile $registry
 }
 
 @test "podman login inconsistent authfiles" {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### Checklist

Ensure you have completed the following checklist for your pull request to be reviewed:
<!-- Use [x] to mark as done, or click the checkbox after opening PR -->

- [x] I have read and understood our [contributing guidelines](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md) and will not have more than two open PRs as a new contributor.
- [x] PR description, commit message, and GitHub comments are human-written, per [LLM Policy](https://github.com/podman-container-tools/community/blob/main/LLM_POLICY.md)
- [x] Certify you wrote the patch or otherwise have the right to pass it on as an open-source patch by signing all
commits. (`git commit -s`). (If needed, use `git commit -s --amend`).  The author email must match
the sign-off email address. See [CONTRIBUTING.md](https://github.com/podman-container-tools/podman/blob/main/CONTRIBUTING.md#sign-your-prs)
for more information.
- [x] Referenced issues using `Fixes: #00000` in commit message (if applicable)
- [x] [Tests](https://github.com/podman-container-tools/podman/tree/main/test#readme) have been added/updated (or no tests are needed)
- [x] [Documentation](https://github.com/podman-container-tools/podman/blob/main/docs/README.md) has been updated (or no documentation changes are needed)
- [x] All commits pass `make validatepr` (format/lint checks)
- [x] [Release note](https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md) entered in the section below (or `None` if no user-facing changes)

#### Does this PR introduce a user-facing change?

The documentation for --mount and --volume states that idmap accepts
a boolean value (true or false), but using idmap=true or idmap=false
fails with:

  Error: unknown option "true"

Only the bare `idmap` form works. This is inconsistent with what
the docs say.

This PR fixes parseIDMapMountOption to accept boolean values:
- idmap=true  is now treated the same as bare idmap
- idmap=false cleanly disables idmapping

I also added a nil check in the rootfs idmap path so it is skipped
when idmap=false is used, and updated the docs for --mount and
--volume to reflect the valid syntax.

Fixes: #24249
